### PR TITLE
fix unarchive issue

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,8 +51,6 @@
     list_files: yes
     owner: "{{ server_user }}"
     group: "{{ server_group }}"
-    exclude:
-      - newrelic/newrelic.yml
   become: yes
 
 - name: Copy new newrelic.yml into place

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,6 +52,12 @@
     owner: "{{ server_user }}"
     group: "{{ server_group }}"
   become: yes
+  
+- name: Remove default config if necessary
+  file:
+    path: "{{ server_root }}/newrelic/newrelic.yml"
+    state: absent
+  become: yes
 
 - name: Copy new newrelic.yml into place
   copy:


### PR DESCRIPTION
This PR fixes the issue reported here: https://github.com/newrelic/newrelic-java-agent-ansible-role/issues/13

The code already handles the case where newrelic.yml already exists by backing it up before unarchive is run. This fix makes it so newrelic.yml will automatically be cleaned up after the unarchive if it exists. The code already handles moving newrelic.yml back in place if it was backed up.